### PR TITLE
[Refactor] Utils for `ENV` and `Logger` calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nanoid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres 0.16.0-rc.2 (git+https://github.com/sfackler/rust-postgres)",
  "postgres-derive 0.3.3 (git+https://github.com/SitiSchu/rust-postgres-derive)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ postgres-derive = {git="https://github.com/SitiSchu/rust-postgres-derive"}
 #postgres = "0.16.0-rc.2"
 # Use master for https://github.com/sfackler/rust-postgres/commit/c0fcf34eb4877c2141ea9c823835db79c9153958
 postgres = {git="https://github.com/sfackler/rust-postgres"}
-serde = "1.0"
-serde_json = "1.0"
+serde = "1.0.8"
+serde_json = "1.0.2"
 dirs = "2.0"
 failure = "0.1"
+lazy_static = "1.3.0"
 
 [dev-dependencies]
 actix-service = "0.4"

--- a/example.config.toml
+++ b/example.config.toml
@@ -1,6 +1,10 @@
-[general]
+# All fields are required for now
+token_size = 64
 # Telegram ID of the master account
-masterid = 1234578
+masterid = 777000
 
 [database]
+host = "127.0.0.1"
 password = "password"
+username = "SpamWatchAPI"
+name = "SpamWatchAPI"

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,7 +1,6 @@
 use postgres::{Client, Config, NoTls, Row};
 use postgres_derive::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
-use slog::Logger;
 
 use crate::settings;
 use crate::utils;
@@ -20,7 +19,6 @@ pub enum Permission {
 
 pub struct Database {
     conn: Client,
-    logger: Logger,
 }
 
 #[derive(Debug, Serialize)]
@@ -33,27 +31,26 @@ pub struct Token {
 
 impl Database {
     pub fn new() -> BoxResult<Database> {
-        let logger = utils::logger();
-        debug!(logger, "Connecting to database";
-         "host" => config!(database.host),
-         "port" => config!(database.port),
-         "name" => config!(database.name),
-         "username" => config!(database.username));
+        debug!(utils::LOGGER, "Connecting to database";
+         "host" => &settings::ENV.database.host,
+         "port" => settings::ENV.database.port,
+         "name" => &settings::ENV.database.name,
+         "username" => &settings::ENV.database.username);
         let conn = Config::new()
-            .host(&config!(database.host))
-            .port(config!(database.port))
-            .dbname(&config!(database.name))
-            .user(&config!(database.username))
-            .password(&config!(database.password))
+            .host(&settings::ENV.database.host)
+            .port(settings::ENV.database.port)
+            .dbname(&settings::ENV.database.name)
+            .user(&settings::ENV.database.username)
+            .password(&settings::ENV.database.password)
             .application_name(&env!("CARGO_PKG_NAME"))
             .connect(NoTls)?;
-        debug!(logger, "Connected to PostgreSQL");
-        Ok(Database { conn, logger })
+        debug!(utils::LOGGER, "Connected to PostgreSQL");
+        Ok(Database { conn })
     }
 
     pub fn setup_tables(&mut self) -> Result<(), postgres::Error> {
         let create_banlist = "CREATE TABLE IF NOT EXISTS banlist (id integer NOT NULL PRIMARY KEY, reason Text NOT NULL, date timestamp NOT NULL);";
-        debug!(self.logger, "Creating Table if it doesn't exist";
+        debug!(utils::LOGGER, "Creating Table if it doesn't exist";
             "query" => create_banlist, "name" => "banlist");
         self.conn.simple_query(create_banlist)?;
 
@@ -64,7 +61,7 @@ impl Database {
                     CREATE TYPE permission AS ENUM ('User', 'Admin', 'Root');
                 END IF;
             END$$;";
-        debug!(self.logger, "Creating type `permission` if it doesn't exist";
+        debug!(utils::LOGGER, "Creating type `permission` if it doesn't exist";
             "query" => permissions_enum, "name" => "banlist");
         self.conn.simple_query(permissions_enum)?;
 
@@ -75,7 +72,7 @@ impl Database {
                 permissions permission NOT NULL,
                 userid integer NOT NULL);";
 
-        debug!(self.logger, "Creating Table if it doesn't exist";
+        debug!(utils::LOGGER, "Creating Table if it doesn't exist";
             "query" => create_tokens,  "name" => "tokens");
         self.conn.simple_query(create_tokens)?;
         Ok(())
@@ -83,22 +80,22 @@ impl Database {
 
     pub fn create_genesis_token(&mut self) -> BoxResult<()> {
         let get_genesis_token = "SELECT * FROM tokens WHERE id = 1;";
-        debug!(self.logger, "Checking if Genesis Token exists";
+        debug!(utils::LOGGER, "Checking if Genesis Token exists";
             "query" => get_genesis_token);
         if self.conn.query(get_genesis_token, &[])?.is_empty() {
-            info!(self.logger, "Genesis Token doesn't exist. Creating one";
-                "size" => config!(token_size));
-            let token = self.create_token(Permission::Root, config!(masterid))?;
-            info!(self.logger, "Created Genesis Token `{}`. Write this down, this will be the only time you see it.", token)
+            info!(utils::LOGGER, "Genesis Token doesn't exist. Creating one";
+                "size" => settings::ENV.token_size);
+            let token = self.create_token(Permission::Root, settings::ENV.masterid)?;
+            info!(utils::LOGGER, "Created Genesis Token `{}`. Write this down, this will be the only time you see it.", token)
         } else {
-            debug!(self.logger, "Genesis Token exists. Skipping creation.")
+            debug!(utils::LOGGER, "Genesis Token exists. Skipping creation.")
         }
         Ok(())
     }
 
     pub fn get_tokens(&mut self) -> BoxResult<Vec<Token>> {
         let get_all_tokens = "SELECT * FROM tokens;";
-        debug!(self.logger, "Getting all tokens"; "query" => get_all_tokens);
+        debug!(utils::LOGGER, "Getting all tokens"; "query" => get_all_tokens);
         let result: Vec<Row> = self.conn.query(get_all_tokens, &[])?;
         Ok(result.into_iter()
                  .map(|row| Token {
@@ -112,7 +109,7 @@ impl Database {
 
     pub fn get_token_by_id(&mut self, token_id: i32) -> BoxResult<Vec<Token>> {
         let get_token_by_id = "SELECT * FROM tokens WHERE id = $1;";
-        debug!(self.logger, "Getting token by id";
+        debug!(utils::LOGGER, "Getting token by id";
             "id" => token_id, "query" => get_token_by_id);
         let result: Vec<Row> = self.conn.query(get_token_by_id, &[&token_id])?;
         // Since there shouldn't be more than one token for a ID taking the first index should be fine.
@@ -127,14 +124,14 @@ impl Database {
     }
 
     pub fn create_token(&mut self, permission: Permission, userid: i32) -> BoxResult<String> {
-        let token = nanoid::generate(config!(token_size) as usize);
+        let token = nanoid::generate(settings::ENV.token_size as usize);
         let insert_token = "
             INSERT INTO tokens (
                 token,
                 permissions,
                 userid)
             VALUES ($1, $2, $3);";
-        debug!(self.logger, "Creating Token";
+        debug!(utils::LOGGER, "Creating Token";
          "query" => insert_token, "permission" => format!("{:?}", permission));
         self.conn.execute(insert_token, &[&token, &permission, &userid])?;
         Ok(token)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,10 @@ mod routes;
 mod tests;
 
 fn setup_database() -> BoxResult<i32> {
-    let logger = utils::logger();
     let mut db = match Database::new() {
         Ok(d) => d,
         Err(e) => {
-            error!(logger, "A Error occured while connecting to PostgreSQL"; "error" => e.to_string());
+            error!(utils::LOGGER, "A Error occured while connecting to PostgreSQL"; "error" => e.to_string());
             return Ok(1);
         }
     };
@@ -36,18 +35,17 @@ fn setup_database() -> BoxResult<i32> {
 }
 
 fn run() -> BoxResult<i32> {
-    let logger = utils::logger();
-    info!(logger, "Starting {}", env!("CARGO_PKG_NAME"); "version" => &env!("CARGO_PKG_VERSION"));
-    if config!(masterid) == 777000 {
-        warn!(logger, "MasterID not set. Defaulting to Telegrams id (777000). To avoid this set `masterid` under the `general` section in the config.")
+    info!(utils::LOGGER, "Starting {}", env!("CARGO_PKG_NAME"); "version" => &env!("CARGO_PKG_VERSION"));
+    if settings::ENV.masterid == 777000 {
+        warn!(utils::LOGGER, "MasterID not set. Defaulting to Telegrams id (777000). To avoid this set `masterid` under the `general` section in the config.")
     }
-    info!(logger, "Master ID is {}", config!(masterid));
+    info!(utils::LOGGER, "Master ID is {}", settings::ENV.masterid);
     let db_code = setup_database()?;
     if db_code > 0 {
         return Ok(db_code);
     }
-    let location = format!("{}:{}", config!(server.host), config!(server.port));
-    info!(logger, "Starting Server on {}", location);
+    let location = format!("{}:{}", settings::ENV.server.host, settings::ENV.server.port);
+    info!(utils::LOGGER, "Starting Server on {}", location);
     HttpServer::new(|| {
         App::new()
             .service(web::resource("/").route(

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -6,20 +6,19 @@ use crate::errors::UserError;
 use crate::utils;
 
 pub fn get_tokens() -> Result<HttpResponse, UserError> {
-    let logger = utils::logger();
     let mut db = Database::new()
         .map_err(|e| {
-            error!(logger, "{}", e);
+            error!(utils::LOGGER, "{}", e);
             UserError::Internal
         })?;
     let tokens = db.get_tokens()
                    .map_err(|e| {
-                       error!(logger, "{}", e);
+                       error!(utils::LOGGER, "{}", e);
                        UserError::Internal
                    })?;
     let tokens_json = serde_json::to_value(tokens)
         .map_err(|e| {
-            error!(logger, "{}", e);
+            error!(utils::LOGGER, "{}", e);
             UserError::Internal
         })?;
 
@@ -27,24 +26,23 @@ pub fn get_tokens() -> Result<HttpResponse, UserError> {
 }
 
 pub fn get_token(req: HttpRequest) -> Result<HttpResponse, UserError> {
-    let logger = utils::logger();
     let mut db = Database::new()
         .map_err(|e| {
-            error!(logger, "{}", e);
+            error!(utils::LOGGER, "{}", e);
             UserError::Internal
         })?;
     let token_id: i32 = req.match_info().get("id").unwrap().parse().map_err(|e| {
-        error!(logger, "{}", e);
+        error!(utils::LOGGER, "{}", e);
         UserError::BadRequest
     })?;
     let token = db.get_token_by_id(token_id).map_err(|e| {
-        error!(logger, "{}", e);
+        error!(utils::LOGGER, "{}", e);
         UserError::Internal
     })?;
     if !token.is_empty() {
         let tokens_json = serde_json::to_value(&token[0])
             .map_err(|e| {
-                error!(logger, "{}", e);
+                error!(utils::LOGGER, "{}", e);
                 UserError::Internal
             })?;
         Ok(HttpResponse::Ok().json(tokens_json))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,9 +2,11 @@ use slog::{Drain, Logger};
 use slog_async;
 use slog_term;
 
+use lazy_static::lazy_static;
+
 pub type BoxResult<T> = Result<T, Box<std::error::Error>>;
 
-pub fn logger() -> Logger {
+fn logger() -> Logger {
     let decorator = slog_term::TermDecorator::new().force_color().build();
     let drain = slog_term::CompactFormat::new(decorator).build().fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
@@ -12,9 +14,6 @@ pub fn logger() -> Logger {
     Logger::root(drain, o!())
 }
 
-#[macro_export]
-macro_rules! config {
-    ($part1:tt) => (settings::Settings::load()?.$part1);
-    // Don't know how else I could do this, so this is the temporary solution
-    ($part1:tt.$part2:tt) => (settings::Settings::load()?.$part1.$part2);
+lazy_static! {
+    pub static ref LOGGER: Logger = logger();
 }


### PR DESCRIPTION
* Shifted to use static variables that can be lazily loaded to
  mod and globally exported. It can become an issue for parallel
  programs, but since we are maintaining them as constants and they are
  not changed at all, this is safe for now.
* Shorten the environment code by serializing and deserializing default
  Settings.
* Made Logger globally available as static, and since we are using
  slog_async, static data here is thread safe as well.