### PR TITLE
[Feat] Easy setup for Postgre on Linux with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 **/*.rs.bk
 .idea
 config.toml
+
+# Remove Secrets
+secrets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ COPY . /app/spamwatch-api
 # re-running our apps faster.
 RUN cargo build
 
+ENV RUST_BACKTRACE 1
+
 CMD ["cargo", "run"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# This is dev version to make the Cargo builds fast and should re-build and run the whole
+# app everytime the container is restarted, as Rust doesn't has a proper way of hot reloading
+FROM rust:latest
+
+WORKDIR /app/spam-watch-api
+
+VOLUME ./ /app/spam-watch-api
+
+# This will cache the library builds, which will ultimately help in
+# re-running our apps faster.
+RUN cargo build
+
+CMD ["cargo", "run"]
+

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,16 +1,9 @@
-# This is dev version to make the Cargo builds fast and should re-build and run the whole
-# app everytime the container is restarted, as Rust doesn't has a proper way of hot reloading
-
-# Keeping Rust to it's latest version for having the latest Rust Dependency.
-# Once async/await is introduced, we can hard-code the version.
 FROM rust:1.36
 
 WORKDIR /app/spamwatch-api
 
 COPY ./ /app/spamwatch-api
 
-# This will cache the library builds, which will ultimately help in
-# re-running our apps faster.
 RUN cargo build --release
 
 CMD ["cargo", "run"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -3,15 +3,15 @@
 
 # Keeping Rust to it's latest version for having the latest Rust Dependency.
 # Once async/await is introduced, we can hard-code the version.
-FROM rust:latest
+FROM rust:1.36
 
 WORKDIR /app/spamwatch-api
 
-COPY . /app/spamwatch-api
+COPY ./ /app/spamwatch-api
 
 # This will cache the library builds, which will ultimately help in
 # re-running our apps faster.
-RUN cargo build
+RUN cargo build --release
 
 CMD ["cargo", "run"]
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ API server for SpamWatch
 
 Before running `docker-compose` please make sure you have added:
 * Postgres password in `/secrets/.postgres-passwd`
-* Created `config.toml` from `example.config.toml`.
+* Create `config.toml` from `example.config.toml`.
+  - Do change the hostname for [database] config to `host = "postgres"`
 
 ```
 docker-compose up [-d]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Spam Watch API
+# SpamWatchAPI
 
-API server for Spam Watch Bot
+API server for SpamWatch
 
 ## Running via Docker
 
 Before running `docker-compose` please make sure you have added:
-* Postgres password in `/secrets/.postgre-passwd`
+* Postgres password in `/secrets/.postgres-passwd`
 * Created `config.toml` from `example.config.toml`.
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Spam Watch API
+
+API server for Spam Watch Bot
+
+## Running via Docker
+
+Before running `docker-compose` please make sure you have added:
+* Postgres password in `/secrets/.postgre-passwd`
+* Created `config.toml` from `example.config.toml`.
+
+```
+docker-compose up [-d]
+```
+

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,6 +23,4 @@ services:
       dockerfile: Dockerfile
     ports:
       - '6345:6345'
-    volumes:
-      - ${PWD}:/app/spamwatch-api
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,10 +7,8 @@ secrets:
 services:
   postgres:
     image: postgres:11.4-alpine
-    # for production we can remove this exposed ports, as it helps in security
-    # while debugging for db in prod, should be done via a client container.
-    ports:
-      - '5432:5432'
+    # for production we don't need to expose ports
+      - '5432'
     secrets:
       - postgres_passwd
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    depends_on:
+      - postgres
     ports:
       - '6345:6345'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.7"
+
+secrets:
+  postgres_passwd:
+    file: ./secrets/.postgres-passwd
+
+services:
+  postgres:
+    image: postgres:11.4-alpine
+    # for production we can remove this exposed ports, as it helps in security
+    # while debugging for db in prod, should be done via a client container.
+    ports:
+      - '5432:5432'
+    secrets:
+      - postgres_passwd
+    environment:
+      POSTGRES_USER: SpamWatchAPI
+      POSTGRES_DB: SpamWatchAPI
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_passwd
+  api:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - '6345:6345'
+    volumes:
+      - ./:/app/spam-watch-api
+

--- a/docker-postgres.sh
+++ b/docker-postgres.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-docker run \
-  --name spam-watch-postgres \
-  -p 5432:5432 \
-  -e POSTGRES_PASSWORD=sub123 \
-  -e POSTGRES_USER="spam-watch" \
-  -e POSTGRES_DB="spam-watch-db" \
-  postgres

--- a/docker-postgres.sh
+++ b/docker-postgres.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+docker run \
+  --name spam-watch-postgres \
+  -p 5432:5432 \
+  -e POSTGRES_PASSWORD=sub123 \
+  -e POSTGRES_USER="spam-watch" \
+  -e POSTGRES_DB="spam-watch-db" \
+  postgres

--- a/example.config.toml
+++ b/example.config.toml
@@ -5,6 +5,7 @@ masterid = 777000
 
 [database]
 host = "127.0.0.1"
+port = 5432
 password = "password"
 username = "SpamWatchAPI"
 name = "SpamWatchAPI"

--- a/example.config.toml
+++ b/example.config.toml
@@ -8,3 +8,9 @@ host = "127.0.0.1"
 password = "password"
 username = "SpamWatchAPI"
 name = "SpamWatchAPI"
+
+[server]
+# this is required for docker containers, to be available from
+# bridge, for any exposed port
+host = "0.0.0.0"
+port = 6345


### PR DESCRIPTION
## Context
Have added Docker setup for dev environment, where a user needs to do some pre-setup as mentioned in [README.md](https://github.com/SpamWatch/SpamWatchAPI/blob/6b803a5cc5d54bf6f8480115cce8fbd92bba40e9/README.md) and just run `docker-compose up` for the services to start.

Prod Docker setup has been added as well, but as extra files. We can take a reference from them and update USERNAME/DBNAME when deployed to prod.